### PR TITLE
Enhance live data provider with replay and canonical futures support

### DIFF
--- a/QuantConnect.DataBento/DataBentoHistoryProivder.cs
+++ b/QuantConnect.DataBento/DataBentoHistoryProivder.cs
@@ -101,10 +101,13 @@ namespace QuantConnect.Lean.DataSource.DataBento
         /// <returns>An enumerable of BaseData points</returns>
         public IEnumerable<BaseData>? GetHistory(HistoryRequest request)
         {
+            // DIAGNOSTIC: Log that we're being called
+            Log.Trace($"DataBentoHistoryProvider.GetHistory(): Symbol={request.Symbol}, Type={request.DataType}, TickType={request.TickType}, Resolution={request.Resolution}, IsCanonical={request.Symbol.IsCanonical()}, Start={request.StartTimeUtc}, End={request.EndTimeUtc}");
+
             if (request.Symbol.IsCanonical() ||
                 !IsSupported(request.Symbol.SecurityType, request.DataType, request.TickType, request.Resolution))
             {
-                // It is Logged in IsSupported(...)
+                Log.Trace($"DataBentoHistoryProvider.GetHistory(): Rejecting request - IsCanonical={request.Symbol.IsCanonical()}, IsSupported={(request.Symbol.IsCanonical() ? "N/A" : IsSupported(request.Symbol.SecurityType, request.DataType, request.TickType, request.Resolution).ToString())}");
                 return null;
             }
 


### PR DESCRIPTION
## Summary
Multiple enhancements to the live data provider for better LEAN integration.

## Features
- Add `[Export]` attribute for MEF plugin discovery
- Add intraday replay support via `databento-replay-start` config
  - `"0"` for full replay (up to 24 hours)
  - ISO datetime for replay from specific time
  - Omit for 15-minute default lookback
- Support canonical (continuous) futures symbols
- Use tick-level schemas (trades, mbp-1) for live streaming
  - LEAN aggregator consolidates ticks into bars properly

## Improvements
- Reduce logging verbosity (remove per-tick spam)
- Add controlled logging for trade bars (first 10, then every 50th)
- Add diagnostic logging to history provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)